### PR TITLE
Cuts down on the perl Record.pm warnings

### DIFF
--- a/marc-record/lib/MARC/Record.pm
+++ b/marc-record/lib/MARC/Record.pm
@@ -199,16 +199,16 @@ sub field {
 
     my @list = ();
     for my $tag ( @specs ) {
-        my $regex = $field_regex{ $tag };
+        my $regex = (defined $tag) ? $field_regex{ $tag } : undef;
 
         # Compile & stash it if necessary
-        if ( not defined $regex ) {
+        if ( not defined $regex and defined $tag ) {
             $regex = qr/^$tag$/;
             $field_regex{ $tag } = $regex;
         } # not defined
 
         for my $maybe ( $self->fields ) {
-            if ( $maybe->tag =~ $regex ) {
+            if ( defined $regex and $maybe->tag =~ $regex ) {
                 return $maybe unless wantarray;
 
                 push( @list, $maybe );


### PR DESCRIPTION
Cuts down on the perl warnings when an undefined value makes it's way into the field sub.

Tested on 120k bibs for a migration. Tested before/after and found that the result was identical but with the patch, much less noise!

This is the error message without the patch:

Use of uninitialized value $tag in hash element at /usr/share/perl5/MARC/Record.pm line 202.
(repeated thousands of times, flooding the standard output)